### PR TITLE
修改阿里源为清华源，并不再安装PPA。

### DIFF
--- a/docker/infini-sql/Dockerfile
+++ b/docker/infini-sql/Dockerfile
@@ -6,9 +6,9 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # 设置工作目录
 WORKDIR /app
-# 替换为阿里云源
-RUN sed -i 's/archive.ubuntu.com/mirrors.aliyun.com/g' /etc/apt/sources.list && \
-  sed -i 's/security.ubuntu.com/mirrors.aliyun.com/g' /etc/apt/sources.list && \
+# 替换为清华源
+RUN sed -i 's/archive.ubuntu.com/mirrors.tuna.tsinghua.edu.cn/g' /etc/apt/sources.list && \
+  sed -i 's/security.ubuntu.com/mirrors.tuna.tsinghua.edu.cn/g' /etc/apt/sources.list && \
   apt-get update
 
 # 更新包列表并安装基础依赖
@@ -17,12 +17,10 @@ RUN apt-get install -y \
   wget \
   unzip \
   git \
-  build-essential \
-  software-properties-common 
+  build-essential 
 
 # 安装Python 3.10+
-RUN apt-get install -y software-properties-common \
-  python3.11 \
+RUN apt-get install -y python3.11 \
   python3-pip \
   python3.11-dev \
   python3-setuptools \

--- a/docker/infini-synapse/Dockerfile
+++ b/docker/infini-synapse/Dockerfile
@@ -6,10 +6,10 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # 设置工作目录
 WORKDIR /app
-# 替换为阿里云源
-RUN sed -i 's/archive.ubuntu.com/mirrors.aliyun.com/g' /etc/apt/sources.list && \
-    sed -i 's/security.ubuntu.com/mirrors.aliyun.com/g' /etc/apt/sources.list && \
-    apt-get update
+# 替换为清华源
+RUN sed -i 's/archive.ubuntu.com/mirrors.tuna.tsinghua.edu.cn/g' /etc/apt/sources.list && \
+  sed -i 's/security.ubuntu.com/mirrors.tuna.tsinghua.edu.cn/g' /etc/apt/sources.list && \
+  apt-get update
 
 # 更新包列表并安装基础依赖
 RUN apt-get install -y \
@@ -17,12 +17,10 @@ RUN apt-get install -y \
     wget \
     unzip \
     git \
-    build-essential \
-    software-properties-common 
+    build-essential 
 
 # 安装Python 3.10+
-RUN apt-get install -y software-properties-common \
-  python3.11 \
+RUN apt-get install -y python3.11 \
   python3-pip \
   python3.11-dev \
   python3-setuptools \


### PR DESCRIPTION
解决这个报错问题：failed to solve: process "/bin/sh -c apt-get install -y software-properties-common   python3.11   python3-pip   python3.11-dev   python3-setuptools   && ln -sf /usr/bin/python3.11 /usr/bin/python3   && ln -sf /usr/bin/python3.11 /usr/bin/python" did not complete successfully: exit code: 100

有的人无法连上Ubuntu的ppa服务器，导致无法安装python3.11
去掉ppa，则阿里源找不到python3.11的软件包
只有用清华源的时候，才能找到并安装python3.11软件包

具体见：https://skywalk.blog.csdn.net/article/details/148729780

